### PR TITLE
Permit Rails 8.0

### DIFF
--- a/atomic_admin.gemspec
+++ b/atomic_admin.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails", "~> 7.0"
+  spec.add_dependency "rails", ">= 7.0", "< 9.0"
 end


### PR DESCRIPTION
There don't seem to be any changes that are an issue, so permit any Rails 8 and up releases as well