### PR TITLE
Support Old Admin Routes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atomic_admin (2.0.0.beta.2)
+    atomic_admin (2.0.0.beta.3)
       rails (>= 7.0, < 9.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atomic_admin (2.0.0.beta.1)
+    atomic_admin (2.0.0.beta.2)
       rails (>= 7.0, < 9.0)
 
 GEM

--- a/app/controllers/atomic_admin/api/admin/v0/admin_controller.rb
+++ b/app/controllers/atomic_admin/api/admin/v0/admin_controller.rb
@@ -1,0 +1,10 @@
+module AtomicAdmin::Api::Admin::V0
+  BASE_CONTROLLER = if AtomicAdmin.authenticating_base_controller_class
+                      AtomicAdmin.authenticating_base_controller_class.constantize
+                    else
+                      AtomicAdmin::Api::Admin::V0::AuthenticatingApplicationController
+                    end
+
+  class AdminController < BASE_CONTROLLER
+  end
+end

--- a/app/controllers/atomic_admin/api/admin/v0/atomic_lti_install_controller.rb
+++ b/app/controllers/atomic_admin/api/admin/v0/atomic_lti_install_controller.rb
@@ -1,0 +1,36 @@
+module AtomicAdmin::Api::Admin::V0
+  class AtomicLtiInstallController < AdminController
+    def install_params
+      params.permit(:iss, :client_id)
+    end
+
+    def find_install
+      AtomicLti::Install.find_by(id: params[:id])
+    end
+
+    def index
+      render json: AtomicLti::Install.all.order(:id).paginate(page: params[:page], per_page: 30)
+    end
+
+    def create
+      AtomicLti::Install.create!(install_params)
+    end
+
+    def show
+      install = find_install
+      render json: install
+    end
+
+    def update
+      install = find_install
+      result = install.update!(install_params)
+      render json: result
+    end
+
+    def destroy
+      install = find_install
+      install.destroy
+      render json: install
+    end
+  end
+end

--- a/app/controllers/atomic_admin/api/admin/v0/atomic_lti_platform_controller.rb
+++ b/app/controllers/atomic_admin/api/admin/v0/atomic_lti_platform_controller.rb
@@ -1,0 +1,43 @@
+module AtomicAdmin::Api::Admin::V0
+  class AtomicLtiPlatformController < AdminController
+    def platform_params
+      params.permit(:iss, :jwks_url, :token_url, :oidc_url)
+    end
+
+    def find_platform
+      AtomicLti::Platform.find_by(id: params[:id])
+    end
+
+    def index
+      page = AtomicLti::Platform.all.order(:id).paginate(page: params[:page], per_page: 30)
+
+      render json: {
+        platforms: page,
+        page: params[:page],
+        total_pages: page.total_pages
+      }
+    end
+
+    def create
+      platform = AtomicLti::Platform.create!(platform_params)
+      render json: { platform: platform }
+    end
+
+    def show
+      platform = find_platform
+      render json: platform
+    end
+
+    def update
+      platform = find_platform
+      platform.update!(platform_params)
+      render json: { platform: find_platform }
+    end
+
+    def destroy
+      platform = find_platform
+      platform.destroy
+      render json: platform
+    end
+  end
+end

--- a/app/controllers/atomic_admin/api/admin/v0/atomic_tenant_client_id_strategy_controller.rb
+++ b/app/controllers/atomic_admin/api/admin/v0/atomic_tenant_client_id_strategy_controller.rb
@@ -1,0 +1,59 @@
+module AtomicAdmin::Api::Admin::V0
+  class AtomicTenantClientIdStrategyController < AdminController
+
+    if AtomicAdmin.client_id_strategy_before_action.present?
+      before_action AtomicAdmin.client_id_strategy_before_action, only: [:create, :update]
+    end
+
+    def pinned_client_id_params
+      params.permit(:iss, :client_id, :application_instance_id)
+    end
+
+    def find_pinned_client_id
+      AtomicTenant::PinnedClientId.find_by(id: params[:id])
+    end
+
+    def search
+      page = AtomicTenant::PinnedClientId
+        .where(application_instance_id: params[:application_instance_id])
+        .order(:id).paginate(page: params[:page], per_page: 30)
+      render json: {
+        pinned_client_ids: page,
+        page: params[:page],
+        total_pages: page.total_pages
+      }
+    end
+
+    # def index
+    #   page = AtomicTenant::PinnedClientId.all.order(:id).paginate(page: params[:page], per_page: 30)
+    #   render json: {
+    #     pinned_client_ids: page,
+    #     page: params[:page],
+    #     total_pages: page.total_pages
+    #   }
+    # end
+
+    def create
+      result = AtomicTenant::PinnedClientId.create!(pinned_client_id_params)
+      render json: { pinned_client_id: result }
+    end
+
+    def show
+      pinned_client_id = find_pinned_client_id
+      render json: {pinned_client_id: pinned_client_id}
+    end
+
+    # def update
+    #   pinned_client_id = find_pinned_client_id
+    #   pinned_client_id.update!(pinned_client_id_params)
+
+    #   render json: {pinned_client_id: find_pinned_client_id}
+    # end
+
+    def destroy
+      pinned_client_id = find_pinned_client_id
+      pinned_client_id.destroy
+      render json: { pinned_client_id: pinned_client_id }
+    end
+  end
+end

--- a/app/controllers/atomic_admin/api/admin/v0/atomic_tenant_deployment_controller.rb
+++ b/app/controllers/atomic_admin/api/admin/v0/atomic_tenant_deployment_controller.rb
@@ -1,0 +1,79 @@
+module AtomicAdmin::Api::Admin::V0
+  class AtomicTenantDeploymentController < AdminController
+    def deployment_params
+      params.permit(:iss, :deployment_id, :application_instance_id)
+    end
+
+    def find_deployment
+      AtomicTenant::LtiDeployment.find_by(id: params[:id])
+    end
+
+    def search
+      tenant_deployments = AtomicTenant::LtiDeployment.
+        where(application_instance_id: params[:application_instance_id]).
+        joins("LEFT OUTER JOIN public.atomic_lti_deployments"\
+          " ON atomic_tenant_lti_deployments.iss = atomic_lti_deployments.iss"\
+          " AND atomic_tenant_lti_deployments.deployment_id = atomic_lti_deployments.deployment_id").
+        order(:id).
+        paginate(page: params[:page], per_page: 30)
+
+      rows = tenant_deployments.pluck(
+        "atomic_tenant_lti_deployments.id",
+        "atomic_tenant_lti_deployments.iss",
+        "atomic_tenant_lti_deployments.deployment_id",
+        "atomic_tenant_lti_deployments.application_instance_id",
+        "atomic_lti_deployments.client_id",
+        "atomic_lti_deployments.platform_guid",
+      )
+
+      page = rows.map do |row|
+        {
+          id: row[0],
+          iss: row[1],
+          deployment_id: row[2],
+          application_instance_id: row[3],
+          client_id: row[4],
+          platform_guid: row[5],
+        }
+      end
+
+      render json: {
+        deployments: page,
+        page: params[:page],
+        total_pages: tenant_deployments.total_pages,
+      }
+    end
+
+    # def index
+    #   page = AtomicTenant::LtiDeployment.all.order(:id).paginate(page: params[:page], per_page: 30)
+    #   render json: {
+    #     deployments: page,
+    #     page: params[:page],
+    #     total_pages: page.total_pages
+    #   }
+    # end
+
+    def create
+      result = AtomicTenant::LtiDeployment.create!(deployment_params)
+      render json: { deployment: result }
+    end
+
+    def show
+      deployment = find_deployment
+      render json: { deployment: deployment }
+    end
+
+    # def update
+    #   deployment = find_deployment
+    #   deployment.update!(deployment_params)
+
+    #   render json: {deployment: find_deployment}
+    # end
+
+    def destroy
+      deployment = find_deployment
+      deployment.destroy
+      render json: { deployment: deployment }
+    end
+  end
+end

--- a/app/controllers/atomic_admin/api/admin/v0/atomic_tenant_platform_guid_strategy_controller.rb
+++ b/app/controllers/atomic_admin/api/admin/v0/atomic_tenant_platform_guid_strategy_controller.rb
@@ -1,0 +1,58 @@
+module AtomicAdmin::Api::Admin::V0
+  class AtomicTenantPlatformGuidStrategyController < AdminController
+    if AtomicAdmin.platform_guid_strategy_before_action.present?
+      before_action AtomicAdmin.platform_guid_strategy_before_action, only: [:create, :update]
+    end
+
+    def pinned_platform_guid_params
+      params.permit(:iss, :platform_guid, :application_id, :application_instance_id)
+    end
+
+    def find_pinned_platform_guid
+      AtomicTenant::PinnedPlatformGuid.find(params[:id])
+    end
+
+    def search
+      page = AtomicTenant::PinnedPlatformGuid
+        .where(application_instance_id: params[:application_instance_id])
+        .order(:id).paginate(page: params[:page], per_page: 30)
+      render json: {
+        pinned_platform_guids: page,
+        page: params[:page],
+        total_pages: page.total_pages
+      }
+    end
+
+    # def index
+    #   page = AtomicTenant::PinnedPlatformGuid.all.order(:id).paginate(page: params[:page], per_page: 30)
+    #   render json: {
+    #     pinned_platform_guids: page,
+    #     page: params[:page],
+    #     total_pages: page.total_pages
+    #   }
+    # end
+
+    def create
+      result = AtomicTenant::PinnedPlatformGuid.create!(pinned_platform_guid_params)
+      render json: { pinned_platform_guid: result }
+    end
+
+    def show
+      pinned_platform_guid = find_pinned_platform_guid
+      render json: {pinned_platform_guid: pinned_platform_guid}
+    end
+
+    def update
+      pinned_platform_guid = find_pinned_platform_guid
+      pinned_platform_guid.update!(pinned_platform_guid_params)
+
+      render json: {pinned_platform_guid: find_pinned_platform_guid}
+    end
+
+    def destroy
+      pinned_platform_guid = find_pinned_platform_guid
+      pinned_platform_guid.destroy
+      render json: { pinned_platform_guid: pinned_platform_guid }
+    end
+  end
+end

--- a/app/controllers/atomic_admin/api/admin/v0/authenticating_application_controller.rb
+++ b/app/controllers/atomic_admin/api/admin/v0/authenticating_application_controller.rb
@@ -1,18 +1,6 @@
 module AtomicAdmin::Api::Admin::V0
   class AuthenticatingApplicationController < ActionController::API
-    include AtomicAdmin::JwtToken
-    # before_action :authenticate_user! # Use validate_token instead for now
-    before_action :validate_token
-    before_action :only_admins!
-
-    private
-
-    def only_admins!
-      user_not_authorized unless current_user.admin?
-    end
-
-    def user_not_authorized(message = "Not Authorized")
-      render json: { message: message, }, status: 401
-    end
+    include RequireJwtToken
+    before_action :validate_internal_token
   end
 end

--- a/app/controllers/atomic_admin/api/admin/v0/authenticating_application_controller.rb
+++ b/app/controllers/atomic_admin/api/admin/v0/authenticating_application_controller.rb
@@ -1,4 +1,4 @@
-module AtomicAdmin
+module AtomicAdmin::Api::Admin::V0
   class AuthenticatingApplicationController < ActionController::API
     include AtomicAdmin::JwtToken
     # before_action :authenticate_user! # Use validate_token instead for now

--- a/app/controllers/atomic_admin/v1/admin_controller.rb
+++ b/app/controllers/atomic_admin/v1/admin_controller.rb
@@ -1,13 +1,12 @@
 module AtomicAdmin::V1
   class AdminController < ActionController::API
     include RequireJwtToken
-    before_action :only_admins!
+    before_action :validate_admin_token
 
     rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
     def record_not_found
       render_error(:not_found)
     end
-
 
     protected
 
@@ -34,12 +33,6 @@ module AtomicAdmin::V1
       end
 
       render json: error, status: status
-    end
-
-    def only_admins!
-      return if is_atomic_admin?
-
-      user_not_authorized if current_user.blank? && !current_user.admin?
     end
 
     def user_not_authorized(message = "Not Authorized")

--- a/app/controllers/concerns/require_jwt_token.rb
+++ b/app/controllers/concerns/require_jwt_token.rb
@@ -1,20 +1,5 @@
 module RequireJwtToken
-   extend ActiveSupport::Concern
-
-  included do
-    attr_accessor :auth_source
-
-    before_action :validate_admin_token
-    before_action :validate_internal_token
-  end
-
-  def is_atomic_admin?
-    self.auth_source == :atomic_admin
-  end
-
-  def is_internal?
-    self.auth_source == :internal
-  end
+  extend ActiveSupport::Concern
 
   protected
 
@@ -23,18 +8,14 @@ module RequireJwtToken
     decoder = AtomicAdmin::JwtToken::JwksDecoder.new(AtomicAdmin.admin_jwks_url)
     token = decoder.decode(encoded_token)&.first
     validate_claims!(token)
-    self.auth_source = :atomic_admin
-
     token
-  rescue Exception => e
-    # Capture all exceptions to let the internal token validation handle it
-    Rails.logger.error "Admin JWT Error occured #{e.inspect}"
-    nil
+
+  rescue JWT::DecodeError, AtomicAdmin::JwtToken::InvalidTokenError => e
+    Rails.logger.error "JWT Error occured #{e.inspect}"
+    render json: { error: "Unauthorized: Invalid token." }, status: :unauthorized
   end
 
   def validate_internal_token
-    return if is_atomic_admin?
-
     encoded_token = get_encoded_token(request)
     decoder = AtomicAdmin::JwtToken::SecretDecoder.new(AtomicAdmin.internal_secret)
     token = decoder.decode!(encoded_token)
@@ -49,7 +30,6 @@ module RequireJwtToken
     @user = User.find(token["user_id"])
 
     sign_in(@user, event: :authentication, store: false)
-    self.auth_source = :internal
   rescue JWT::DecodeError, AtomicAdmin::JwtToken::InvalidTokenError => e
     Rails.logger.error "Internal JWT Error occured #{e.inspect}"
     render json: { error: "Unauthorized: Invalid token." }, status: :unauthorized

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,21 @@
 AtomicAdmin::Engine.routes.draw do
   namespace :api do
     namespace :admin do
+      # NOTE: these are the "legacy" routes that the old admin app relies on. They don't follow the same conventions as the new API.
+      # They are also not namespaces under /api/admin/v0 but rather /api/admin/*
+      scope module: "v0" do
+        resources :atomic_lti_platform
+        resources :atomic_lti_install
+        resources :atomic_tenant_deployment
+        post '/atomic_tenant_deployment/search', to: 'atomic_tenant_deployment#search'
+
+        resources :atomic_tenant_platform_guid_strategy
+        post '/atomic_tenant_platform_guid_strategy/search', to: 'atomic_tenant_platform_guid_strategy#search'
+
+        resources :atomic_tenant_client_id_strategy
+        post '/atomic_tenant_client_id_strategy/search', to: 'atomic_tenant_client_id_strategy#search'
+      end
+
       namespace :v1 do
         resources :lti_platforms
         resources :lti_installs

--- a/lib/atomic_admin.rb
+++ b/lib/atomic_admin.rb
@@ -11,6 +11,8 @@ module AtomicAdmin
   mattr_accessor :application_interactions, default: AtomicAdmin::Interaction::Manager.new
   mattr_accessor :application_instance_interactions, default: AtomicAdmin::Interaction::Manager.new
   mattr_accessor :authenticating_base_controller_class, default: nil
+  mattr_accessor :client_id_strategy_before_action, default: nil
+  mattr_accessor :platform_guid_strategy_before_action, default: nil
 
   def self.configure
     yield self

--- a/lib/atomic_admin.rb
+++ b/lib/atomic_admin.rb
@@ -10,6 +10,7 @@ module AtomicAdmin
   mattr_accessor :internal_secret
   mattr_accessor :application_interactions, default: AtomicAdmin::Interaction::Manager.new
   mattr_accessor :application_instance_interactions, default: AtomicAdmin::Interaction::Manager.new
+  mattr_accessor :authenticating_base_controller_class, default: nil
 
   def self.configure
     yield self

--- a/lib/atomic_admin/version.rb
+++ b/lib/atomic_admin/version.rb
@@ -1,3 +1,3 @@
 module AtomicAdmin
-  VERSION = "2.0.0.beta.2".freeze
+  VERSION = "2.0.0.beta.3".freeze
 end


### PR DESCRIPTION
Pulls in old controllers from main & mounts them in the correct locations so the old admin app should continue to work as-expected