### PR TITLE
feat: add request_stats to application_instances_controller

### DIFF
--- a/app/controllers/atomic_admin/v1/application_instances_controller.rb
+++ b/app/controllers/atomic_admin/v1/application_instances_controller.rb
@@ -15,6 +15,7 @@ module AtomicAdmin::V1
         end
 
       @application_instances, meta = filter(@application_instances)
+      @stats = get_stats_for_instances(@application_instances)
 
       render json: {
         application_instances: json_for_collection(@application_instances),
@@ -24,6 +25,7 @@ module AtomicAdmin::V1
 
     def show
       @application_instance = ApplicationInstance.find(params[:id])
+      @stats = get_stats_for_instances([@application_instance])
       render json: { application_instance: json_for(@application_instance) }
     end
 
@@ -67,6 +69,27 @@ module AtomicAdmin::V1
       render json: { interactions: interactions }
     end
 
+    def get_stats_for_instances(instances)
+      tenants = instances.pluck(:tenant)
+      stats = {}
+      stats[:errors] = RequestStatistic.total_errors_grouped(tenants) if defined?(RequestStatistic)
+      stats[:unique_users] = CachedUniqueUsersByContractDate.unique_users_by_contract_date(instances) if defined?(CachedUniqueUsersByContractDate)
+      stats[:max_users_month] = CachedUniqueUsersByMonth.max_monthly_unique_users(instances) if defined?(CachedUniqueUsersByMonth)
+
+      stats
+    end
+
+    def request_stats(instance)
+      tenant = instance.tenant
+
+      {
+        unique_users_in_contract: @stats.dig(:unique_users, tenant) || 0,
+        day_1_errors: @stats.dig(:errors, 0, tenant) || 0,
+        day_7_errors: @stats.dig(:errors, 7, tenant) || 0,
+        max_users_month: @stats.dig(:max_users_month, tenant) || 0,
+      }
+    end
+
     def json_for(instance)
       json = instance.as_json(include: [:application, :site])
 
@@ -76,6 +99,7 @@ module AtomicAdmin::V1
       json["license_end_date"] = instance.license_end_date&.strftime("%Y-%m-%d") if instance.respond_to?(:license_end_date)
       json["is_paid"] = instance.paid_at.present? if instance.respond_to?(:paid_at)
       json["lti_config_xml"] = instance.lti_config_xml if instance.respond_to?(:lti_config_xml)
+      json["request_stats"] = request_stats(instance)
 
       json
     end

--- a/atomic_admin.gemspec
+++ b/atomic_admin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 7.0", "< 9.0"
-  spec.add_dependency "atomic_lti", ">= 1.5.0", "< 2.0.0"
+  spec.add_dependency "atomic_lti", ">= 1.5.0", "< 5.0.0"
   spec.add_dependency "atomic_tenant", ">= 1.2.0", "< 2.0.0"
   spec.add_dependency "httparty", ">= 0.24.0", "< 1.0.0"
 end

--- a/lib/atomic_admin/version.rb
+++ b/lib/atomic_admin/version.rb
@@ -1,3 +1,3 @@
 module AtomicAdmin
-  VERSION = "2.0.1".freeze
+  VERSION = "2.1.0".freeze
 end


### PR DESCRIPTION
This PR adds the `request_stats` fields to the app instance controller based on what is in Atomic Assessments currently. From my perusal, this is the same format that the other apps report. If they disagree with how this data is generated, then can override `request_stats(instance)` in their admin controller to provide a different data collection method.

For this to take affect, each app will have to upgrade to v2.1.0. Any app that doesn't will have missing data in the admin panel. 