### PR TITLE
fix: remove request_stats from payload

### DIFF
--- a/app/controllers/atomic_admin/v1/application_instances_controller.rb
+++ b/app/controllers/atomic_admin/v1/application_instances_controller.rb
@@ -140,7 +140,7 @@ module AtomicAdmin::V1
     end
 
     def create_params
-      params.require(:application_instance).except(:is_paid, :lti_config_xml, :site, :application).permit!
+      params.require(:application_instance).except(:is_paid, :lti_config_xml, :site, :application, :request_stats).permit!
     end
 
     def update_params

--- a/lib/atomic_admin/version.rb
+++ b/lib/atomic_admin/version.rb
@@ -1,3 +1,3 @@
 module AtomicAdmin
-  VERSION = "2.1.0".freeze
+  VERSION = "2.1.1".freeze
 end


### PR DESCRIPTION
Saving from skipper was throwing an exception because they payload it was accepting included `request_stats` which isn't a field on ApplicationInstance